### PR TITLE
Add Skunk 1.0.0 module with rollback support and example implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ This is your model — the single source of truth for expected behavior. It's so
 
 ### 3. Write the real implementation
 
+Two integrations are provided out of the box.
+
+#### Doobie
+
+The effect type is `ConnectionIO` — Doobie's own connection action type.
+
 ```scala
 import doobie._
 import doobie.implicits._
@@ -164,30 +170,77 @@ object DoobiePersonRepository extends PersonRepository[ConnectionIO] {
 }
 ```
 
-### 4. Mirror-test them
+#### Skunk
+
+The effect type is `Kleisli[F, Session[F], *]` — a function from a live Skunk session to an `F` action. All composed operations share the same session, so they run in the same transaction.
 
 ```scala
-import cats.effect.IO
-import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
-import org.scalacheck.effect.PropF
-import org.scalacheck.{Arbitrary, Gen}
-import com.dimafeng.testcontainers.PostgreSQLContainer
-import com.dimafeng.testcontainers.munit.TestContainerForAll
-import org.testcontainers.utility.DockerImageName
+import cats.data.Kleisli
+import cats.effect.Async
+import cats.implicits.*
+import skunk.*
+import skunk.codec.all.*
+import skunk.data.Completion
+import skunk.implicits.*
 
-class PersonRepoSpec
+class SkunkPersonRepository[F[_]: Async] extends PersonRepository[[A] =>> Kleisli[F, Session[F], A]] {
+
+  private val personCodec: Codec[Person] =
+    (uuid ~ text ~ int4).imap { case id ~ name ~ age => Person(id, name, age) }(p =>
+      p.id ~ p.name ~ p.age
+    )
+
+  private val createCommand: Command[Void] =
+    sql"""
+      CREATE TABLE IF NOT EXISTS persons (
+        id uuid PRIMARY KEY,
+        name text NOT NULL,
+        age int4 NOT NULL
+      )
+    """.command
+
+  private val insertCommand: Command[Person] =
+    sql"INSERT INTO persons (id, name, age) VALUES ($personCodec)".command
+
+  private val listAllQuery: Query[Void, Person] =
+    sql"SELECT id, name, age FROM persons".query(personCodec)
+
+  private val deleteOlderThanCommand: Command[Long] =
+    sql"DELETE FROM persons WHERE age > ${int8}".command
+
+  def create: Kleisli[F, Session[F], Unit] =
+    Kleisli(_.execute(createCommand).void)
+
+  def insertMany(persons: List[Person]): Kleisli[F, Session[F], Long] = Kleisli { session =>
+    session.prepareR(insertCommand).use(pc => persons.traverse(pc.execute).map(_.length.toLong))
+  }
+
+  def deleteWhenOlderThen(age: Long): Kleisli[F, Session[F], Long] = Kleisli { session =>
+    session.prepareR(deleteOlderThanCommand).use(_.execute(age).map {
+      case Completion.Delete(n) => n.toLong
+      case _                   => 0L
+    })
+  }
+
+  def listAll(): Kleisli[F, Session[F], List[Person]] =
+    Kleisli(_.execute(listAllQuery))
+}
+```
+
+### 4. Mirror-test them
+
+#### Doobie
+
+`DoobieSupport.rollbackTrans` returns a `ConnectionIO ~> F` natural transformation that runs each test inside a transaction and always rolls back, leaving the database clean between property iterations.
+
+```scala
+class DoobiePersonRepositorySpec
     extends CatsEffectSuite
     with ScalaCheckEffectSuite
     with MirraSuite[IO]
     with TestContainerForAll {
 
-  given Arbitrary[Person] = Arbitrary {
-    for {
-      id   <- Gen.uuid
-      name <- Gen.stringOfN(50, Gen.alphaChar)
-      age  <- Gen.posNum[Int]
-    } yield Person(id, name, age)
-  }
+  given Arbitrary[Person] = Arbitrary { /* ... */ }
 
   override val containerDef: PostgreSQLContainer.Def = PostgreSQLContainer.Def(
     dockerImageName = DockerImageName.parse("postgres:15.1"),
@@ -208,31 +261,49 @@ class PersonRepoSpec
 
         assertMirroring {
           algebraUnderTest.model.eval { x =>
-            x.create *>
-              x.insertMany(persons) *>
-              x.listAll()
+            x.create *> x.insertMany(persons) *> x.listAll()
           }
         }
       }
     }
   }
+}
+```
 
-  test("should delete people older then") {
-    PropF.forAllF { (persons: List[Person], age: Int) =>
+#### Skunk
+
+`SkunkSupport.rollbackTrans` does the same for Skunk: opens a session, begins a transaction, and always rolls back. It returns a `Kleisli[F, Session[F], *] ~> F` nat-trans directly, so the test body is identical in structure. Noop otel4s tracing is wired internally — no setup required.
+
+```scala
+class SkunkPersonRepositorySpec
+    extends CatsEffectSuite
+    with ScalaCheckEffectSuite
+    with MirraSuite[IO]
+    with TestContainerForAll {
+
+  given Arbitrary[Person] = Arbitrary { /* ... */ }
+
+  override val containerDef: PostgreSQLContainer.Def = /* same as Doobie */
+
+  test("should insert and read") {
+    PropF.forAllF { (persons: List[Person]) =>
       withContainers { (c: Containers) =>
-        val trans = DoobieSupport.rollbackTrans[IO](
-          "org.postgresql.Driver", c.jdbcUrl, c.username, c.password
-        )
+        SkunkSupport.rollbackTrans[IO](
+          host     = c.container.getHost,
+          port     = c.container.getMappedPort(5432),
+          user     = c.username,
+          database = c.databaseName,
+          password = Some(c.password)
+        ).use { trans =>
+          def algebraUnderTest =
+            new AlgebraUnderTest[PersonRepository, IO, [A] =>> Kleisli[IO, Session[IO], A], Universe](
+              Universe.zero, SkunkPersonRepository[IO], MirraPersonRepository, trans
+            )
 
-        def algebraUnderTest =
-          new AlgebraUnderTest(Universe.zero, DoobiePersonRepository, MirraPersonRepository, trans)
-
-        assertMirroring {
-          algebraUnderTest.model.eval { x =>
-            x.create *>
-              x.insertMany(persons) *>
-              x.deleteWhenOlderThen(age) *>
-              x.listAll()
+          assertMirroring {
+            algebraUnderTest.model.eval { x =>
+              x.create *> x.insertMany(persons) *> x.listAll()
+            }
           }
         }
       }
@@ -255,6 +326,15 @@ Notice there's no assertion logic about _what_ the result should be. No filterin
 
 **`FunctorK` / `SemigroupalK`** — Type classes from [cats-tagless](https://github.com/typelevel/cats-tagless) that allow transforming the effect type of an algebra. These are what make it possible to run a single program against two different interpreters. Derived automatically with `Derive.functorK` / `Derive.semigroupalK`.
 
+## Modules
+
+| Module | What it provides |
+|---|---|
+| `core` | `Mirra[S, A]`, `AlgebraUnderTest`, `MirraSyntax` |
+| `munit` | `MirraSuite[F]` — mix into munit suites |
+| `doobie` | `DoobieSupport.rollbackTrans` — `ConnectionIO ~> F` with always-rollback |
+| `skunk` | `SkunkSupport.rollbackTrans` — `Kleisli[F, Session[F], *] ~> F` with always-rollback |
+
 ## Dependencies
 
 Built with Scala 3.
@@ -263,7 +343,11 @@ Built with Scala 3.
 
 **munit module:** [munit](https://scalameta.org/munit/), [munit-cats-effect](https://github.com/typelevel/munit-cats-effect), [scalacheck-effect-munit](https://github.com/typelevel/scalacheck-effect).
 
-**Example module:** [Doobie](https://github.com/tpolecat/doobie), [Testcontainers](https://www.testcontainers.org/) (PostgreSQL), [ScalaCheck](https://scalacheck.org/).
+**doobie module:** [Doobie](https://github.com/tpolecat/doobie).
+
+**skunk module:** [Skunk](https://github.com/tpolecat/skunk) 1.0.0.
+
+**Example module:** Doobie + Skunk, [Testcontainers](https://www.testcontainers.org/) (PostgreSQL), [ScalaCheck](https://scalacheck.org/).
 
 ## Inspiration
 

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,16 @@ val munit =
     )
     .dependsOn(core)
 
+val skunk =
+  project.in(file("skunk"))
+    .settings(commonSettings)
+    .settings(
+      libraryDependencies ++= Seq(
+        "org.tpolecat" %% "skunk-core" % "1.0.0"
+      )
+    )
+    .dependsOn(core)
+
 def commonSettings = Seq(
   scalaVersion := "3.8.3",
   scalacOptions += "-experimental"
@@ -53,4 +63,4 @@ val example =
         "com.dimafeng" %% "testcontainers-scala-munit" % "0.44.1"
       )
     )
-    .dependsOn(core, munit, doobie)
+    .dependsOn(core, munit, doobie, skunk)

--- a/example/src/main/scala/mirra/SkunkPersonRepository.scala
+++ b/example/src/main/scala/mirra/SkunkPersonRepository.scala
@@ -1,0 +1,56 @@
+package mirra
+
+import cats.data.Kleisli
+import cats.effect.Async
+import cats.implicits.*
+import skunk.*
+import skunk.codec.all.*
+import skunk.data.Completion
+import skunk.implicits.*
+
+class SkunkPersonRepository[F[_]: Async] extends PersonRepository[[A] =>> Kleisli[F, Session[F], A]] {
+
+  private val personCodec: Codec[Person] =
+    (uuid ~ text ~ int4).imap { case id ~ name ~ age => Person(id, name, age) }(p =>
+      p.id ~ p.name ~ p.age
+    )
+
+  private val createCommand: Command[Void] =
+    sql"""
+      CREATE TABLE IF NOT EXISTS persons (
+        id uuid PRIMARY KEY,
+        name text NOT NULL,
+        age int4 NOT NULL
+      )
+    """.command
+
+  private val insertCommand: Command[Person] =
+    sql"INSERT INTO persons (id, name, age) VALUES ($personCodec)".command
+
+  private val listAllQuery: Query[Void, Person] =
+    sql"SELECT id, name, age FROM persons".query(personCodec)
+
+  private val deleteOlderThanCommand: Command[Long] =
+    sql"DELETE FROM persons WHERE age > ${int8}".command
+
+  def create: Kleisli[F, Session[F], Unit] =
+    Kleisli(_.execute(createCommand).void)
+
+  def insertMany(persons: List[Person]): Kleisli[F, Session[F], Long] = Kleisli { session =>
+    session.prepareR(insertCommand).use(pc => persons.traverse(pc.execute).map(_.length.toLong))
+  }
+
+  def deleteWhenOlderThen(age: Long): Kleisli[F, Session[F], Long] = Kleisli { session =>
+    session.prepareR(deleteOlderThanCommand).use(_.execute(age).map {
+      case Completion.Delete(n) => n.toLong
+      case _                   => 0L
+    })
+  }
+
+  def listAll(): Kleisli[F, Session[F], List[Person]] =
+    Kleisli(_.execute(listAllQuery))
+}
+
+object SkunkPersonRepository {
+  def apply[F[_]: Async]: SkunkPersonRepository[F] = new SkunkPersonRepository[F]
+}

--- a/example/src/test/scala/mirra/DoobiePersonRepositorySpec.scala
+++ b/example/src/test/scala/mirra/DoobiePersonRepositorySpec.scala
@@ -13,7 +13,7 @@ import org.scalacheck.effect.PropF
 import org.scalacheck.{Arbitrary, Gen}
 import org.testcontainers.utility.DockerImageName
 
-class PersonRepoSpec extends CatsEffectSuite with ScalaCheckEffectSuite with MirraSuite[IO] with TestContainerForAll {
+class DoobiePersonRepositorySpec extends CatsEffectSuite with ScalaCheckEffectSuite with MirraSuite[IO] with TestContainerForAll {
 
   given Arbitrary[Person] = Arbitrary {
     for {

--- a/example/src/test/scala/mirra/SkunkPersonRepositorySpec.scala
+++ b/example/src/test/scala/mirra/SkunkPersonRepositorySpec.scala
@@ -1,0 +1,79 @@
+package mirra
+
+import cats.effect.IO
+import cats.implicits.*
+import com.dimafeng.testcontainers.PostgreSQLContainer
+import com.dimafeng.testcontainers.munit.TestContainerForAll
+import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
+import org.scalacheck.effect.PropF
+import org.scalacheck.{Arbitrary, Gen}
+import org.testcontainers.utility.DockerImageName
+
+class SkunkPersonRepositorySpec extends CatsEffectSuite with ScalaCheckEffectSuite with MirraSuite[IO] with TestContainerForAll {
+
+  given Arbitrary[Person] = Arbitrary {
+    for {
+      id   <- Gen.uuid
+      name <- Gen.stringOfN(50, Gen.alphaChar)
+      age  <- Gen.posNum[Int]
+    } yield Person(id, name, age)
+  }
+
+  override val containerDef: PostgreSQLContainer.Def = PostgreSQLContainer.Def(
+    dockerImageName = DockerImageName.parse("postgres:15.1"),
+    databaseName = "testcontainer-scala",
+    username = "scala",
+    password = "scala"
+  )
+
+  test("should insert and read") {
+    PropF.forAllF { (persons: List[Person]) =>
+      withContainers { (c: Containers) =>
+        SkunkSupport.rollbackTrans[IO](
+          host     = c.container.getHost,
+          port     = c.container.getMappedPort(5432),
+          user     = c.username,
+          database = c.databaseName,
+          password = Some(c.password)
+        ).use { trans =>
+          def algebraUnderTest =
+            new AlgebraUnderTest[PersonRepository, IO, [A] =>> cats.data.Kleisli[IO, skunk.Session[IO], A], Universe](Universe.zero, SkunkPersonRepository[IO], MirraPersonRepository, trans)
+
+          assertMirroring {
+            algebraUnderTest.model.eval { x =>
+              x.create *>
+                x.insertMany(persons) *>
+                x.listAll()
+            }
+          }
+        }
+      }
+    }
+  }
+
+  test("should delete people older then") {
+    PropF.forAllF { (persons: List[Person], age: Int) =>
+      withContainers { (c: Containers) =>
+        SkunkSupport.rollbackTrans[IO](
+          host     = c.container.getHost,
+          port     = c.container.getMappedPort(5432),
+          user     = c.username,
+          database = c.databaseName,
+          password = Some(c.password)
+        ).use { trans =>
+          def algebraUnderTest =
+            new AlgebraUnderTest[PersonRepository, IO, [A] =>> cats.data.Kleisli[IO, skunk.Session[IO], A], Universe](Universe.zero, SkunkPersonRepository[IO], MirraPersonRepository, trans)
+
+          assertMirroring {
+            algebraUnderTest.model.eval { x =>
+              x.create *>
+                x.insertMany(persons) *>
+                x.deleteWhenOlderThen(age) *>
+                x.listAll()
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/skunk/src/main/scala/mirra/SkunkSupport.scala
+++ b/skunk/src/main/scala/mirra/SkunkSupport.scala
@@ -1,0 +1,41 @@
+package mirra
+
+import cats.data.Kleisli
+import cats.effect.{Async, Resource}
+import cats.effect.std.Console
+import cats.implicits.*
+import cats.~>
+import fs2.io.net.Network
+import org.typelevel.otel4s.metrics.Meter
+import org.typelevel.otel4s.trace.Tracer
+import skunk.Session
+
+object SkunkSupport {
+  def rollbackTrans[F[_]: {Async, Console, Network}](
+    host: String,
+    port: Int = 5432,
+    user: String,
+    database: String,
+    password: Option[String] = None
+  ): Resource[F, ([A] =>> Kleisli[F, Session[F], A]) ~> F] = {
+    given Tracer[F] = Tracer.noop
+    given Meter[F] = Meter.noop
+
+    Session.single[F](
+      host = host,
+      port = port,
+      user = user,
+      database = database,
+      password = password
+    ).flatMap { session =>
+      Resource
+        .make(session.transaction.allocated.map { case (tx, _) => (session, tx) })(
+          { case (_, tx) => tx.rollback.void }
+        )
+        .map { case (session, _) =>
+          new (([A] =>> Kleisli[F, Session[F], A]) ~> F):
+            def apply[A](fa: Kleisli[F, Session[F], A]): F[A] = fa.run(session)
+        }
+    }
+  }
+}


### PR DESCRIPTION
- New `skunk` sbt module wrapping skunk-core 1.0.0; `SkunkSupport.rollbackTrans` opens a session inside a transaction and always rolls back on release, returning a `Kleisli[F, Session[F], *] ~> F` nat-trans ready for use in `AlgebraUnderTest` — mirrors the existing `DoobieSupport.rollbackTrans` API
- `SkunkPersonRepository[F]` in the example module implements `PersonRepository` with effect type `[A] =>> Kleisli[F, Session[F], A]`
- `SkunkPersonRepositorySpec` property-based tests against a testcontainer, identical coverage to the Doobie suite (insert+read, delete-older-than)
- `PersonRepoSpec` renamed to `DoobiePersonRepositorySpec` for consistency