### PR TITLE
Add Maven Central publishing via GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: sbt
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Publish to Maven Central
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          PGP_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: sbt +publishSigned sonatypeBundleRelease

--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,27 @@
 import sbt.Compile
 import sbt.Keys.libraryDependencies
 
+ThisBuild / organization         := "io.github.fristi"
+ThisBuild / organizationName     := "Fristi"
+ThisBuild / version              := "0.1.0"
+ThisBuild / scalaVersion         := "3.8.3"
+ThisBuild / licenses             := List("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0"))
+ThisBuild / homepage             := Some(url("https://github.com/Fristi/mirra"))
+ThisBuild / developers           := List(
+  Developer("Fristi", "Mark de Jong", "av3ng3r@gmail.com", url("https://github.com/Fristi"))
+)
+ThisBuild / sonatypeCredentialHost := "central.sonatype.com"
+ThisBuild / sonatypeRepository     := "https://central.sonatype.com/api/v1/publisher"
+
 val core =
   project.in(file("core"))
     .settings(commonSettings)
     .settings(
+      name := "mirra-core",
       libraryDependencies ++= Seq(
         "org.typelevel" %% "cats-tagless-core" % "0.16.5",
-        "dev.optics" %% "monocle-core"  % "3.3.0",
-        "org.scalameta" %% "munit" % "1.3.0" % Test,
+        "dev.optics"    %% "monocle-core"      % "3.3.0",
+        "org.scalameta" %% "munit"             % "1.3.0" % Test,
       ),
     )
 
@@ -16,8 +29,9 @@ val doobie =
   project.in(file("doobie"))
     .settings(commonSettings)
     .settings(
+      name := "mirra-doobie",
       libraryDependencies ++= Seq(
-        "org.tpolecat"      %% "doobie-core"            % "1.0.0-RC12"
+        "org.tpolecat" %% "doobie-core" % "1.0.0-RC12"
       )
     )
     .dependsOn(core)
@@ -26,9 +40,10 @@ val munit =
   project.in(file("munit"))
     .settings(commonSettings)
     .settings(
+      name := "mirra-munit",
       libraryDependencies ++= Seq(
-        "org.scalameta" %% "munit" % "1.3.0",
-        "org.typelevel" %% "munit-cats-effect" % "2.2.0",
+        "org.scalameta" %% "munit"                   % "1.3.0",
+        "org.typelevel" %% "munit-cats-effect"       % "2.2.0",
         "org.typelevel" %% "scalacheck-effect-munit" % "2.1.0"
       )
     )
@@ -38,6 +53,7 @@ val zioTest =
   project.in(file("zio-test"))
     .settings(commonSettings)
     .settings(
+      name := "mirra-zio-test",
       libraryDependencies ++= Seq(
         "dev.zio" %% "zio"          % "2.1.14",
         "dev.zio" %% "zio-test"     % "2.1.14",
@@ -50,35 +66,35 @@ val skunk =
   project.in(file("skunk"))
     .settings(commonSettings)
     .settings(
+      name := "mirra-skunk",
       libraryDependencies ++= Seq(
         "org.tpolecat" %% "skunk-core" % "1.0.0"
       )
     )
     .dependsOn(core)
 
-def commonSettings = Seq(
-  scalaVersion := "3.8.3",
-  scalacOptions += "-experimental"
-)
-
-
 val example =
   project.in(file("example"))
     .settings(commonSettings)
     .settings(
+      publish / skip := true,
       libraryDependencies ++= Seq(
-        "org.tpolecat"  %% "doobie-core"                          % "1.0.0-RC12",
-        "org.tpolecat"  %% "doobie-postgres"                      % "1.0.0-RC12",
-        "org.tpolecat"  %% "doobie-hikari"                        % "1.0.0-RC12",
-        "dev.optics"    %% "monocle-macro"                        % "3.3.0",
-        "com.dimafeng"  %% "testcontainers-scala-postgresql"      % "0.44.1",
-        "com.dimafeng"  %% "testcontainers-scala-munit"           % "0.44.1",
+        "org.tpolecat"  %% "doobie-core"                        % "1.0.0-RC12",
+        "org.tpolecat"  %% "doobie-postgres"                    % "1.0.0-RC12",
+        "org.tpolecat"  %% "doobie-hikari"                      % "1.0.0-RC12",
+        "dev.optics"    %% "monocle-macro"                      % "3.3.0",
+        "com.dimafeng"  %% "testcontainers-scala-postgresql"    % "0.44.1",
+        "com.dimafeng"  %% "testcontainers-scala-munit"         % "0.44.1",
         // ZIO Test integration
-        "dev.zio"       %% "zio"                                  % "2.1.14"   % Test,
-        "dev.zio"       %% "zio-test"                             % "2.1.14"   % Test,
-        "dev.zio"       %% "zio-test-sbt"                         % "2.1.14"   % Test,
-        "dev.zio"       %% "zio-interop-cats"                     % "23.1.0.3" % Test,
+        "dev.zio"       %% "zio"                                % "2.1.14"   % Test,
+        "dev.zio"       %% "zio-test"                           % "2.1.14"   % Test,
+        "dev.zio"       %% "zio-test-sbt"                       % "2.1.14"   % Test,
+        "dev.zio"       %% "zio-interop-cats"                   % "23.1.0.3" % Test,
       ),
       testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
     )
     .dependsOn(core, munit, doobie, skunk, zioTest)
+
+def commonSettings = Seq(
+  scalacOptions += "-experimental"
+)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")
+addSbtPlugin("com.github.sbt" % "sbt-pgp"      % "2.3.1")


### PR DESCRIPTION
Configures sbt-sonatype + sbt-pgp for publishing core, doobie, and munit modules to Maven Central. Skips example. Workflow triggers on push to master.