### PR TITLE
Add sortBy, sortByDesc, minBy, maxBy, sumBy, groupBy 

### DIFF
--- a/core/src/main/scala/mirra/MirraSyntax.scala
+++ b/core/src/main/scala/mirra/MirraSyntax.scala
@@ -1,6 +1,6 @@
 package mirra
 
-import cats.{Foldable, Functor, FunctorFilter, Monoid}
+import cats.{Foldable, Functor, FunctorFilter, Monoid, Order}
 import cats.implicits._
 import monocle.Lens
 
@@ -88,6 +88,30 @@ trait MirraSyntax {
       }
 
     }
+
+    /** Returns elements sorted ascending by the key produced by `f`. */
+    def sortBy[B: Order](f: A => B)(implicit F: Foldable[F]): Mirra[D, List[A]] =
+      Mirra(mirra.db.map(_.toList.sortWith((x, y) => Order[B].lt(f(x), f(y)))))
+
+    /** Returns elements sorted descending by the key produced by `f`. */
+    def sortByDesc[B: Order](f: A => B)(implicit F: Foldable[F]): Mirra[D, List[A]] =
+      Mirra(mirra.db.map(_.toList.sortWith((x, y) => Order[B].gt(f(x), f(y)))))
+
+    /** Returns the element with the smallest value of `f`, or `None` if empty. */
+    def minBy[B: Order](f: A => B)(implicit F: Foldable[F]): Mirra[D, Option[A]] =
+      Mirra(mirra.db.map(xs => F.minimumByOption(xs)(f)))
+
+    /** Returns the element with the largest value of `f`, or `None` if empty. */
+    def maxBy[B: Order](f: A => B)(implicit F: Foldable[F]): Mirra[D, Option[A]] =
+      Mirra(mirra.db.map(xs => F.maximumByOption(xs)(f)))
+
+    /** Sums the numeric values produced by `f` across all elements. */
+    def sumBy[B](f: A => B)(implicit N: Numeric[B], F: Foldable[F]): Mirra[D, B] =
+      Mirra(mirra.db.map(_.toList.foldLeft(N.zero)((acc, a) => N.plus(acc, f(a)))))
+
+    /** Groups elements by the key produced by `f`. */
+    def groupBy[B](f: A => B)(implicit F: Foldable[F]): Mirra[D, Map[B, List[A]]] =
+      Mirra(mirra.db.map(_.toList.groupBy(f)))
   }
 
 }

--- a/core/src/test/scala/mirra/MirraSpec.scala
+++ b/core/src/test/scala/mirra/MirraSpec.scala
@@ -333,4 +333,72 @@ class MirraSpec extends FunSuite with MirraSyntax {
     )
     assertEquals(result, List((a, "a")))
   }
+
+  // ------------------------------------------------------------------
+  // sortBy / sortByDesc
+  // ------------------------------------------------------------------
+
+  test("sortBy orders elements ascending by key") {
+    val state = World(List(c, a, b), Nil)
+    assertEquals(run(Mirra.all(World.items).sortBy(_.value), state), List(a, b, c))
+  }
+
+  test("sortByDesc orders elements descending by key") {
+    val state = World(List(a, b, c), Nil)
+    assertEquals(run(Mirra.all(World.items).sortByDesc(_.value), state), List(c, b, a))
+  }
+
+  test("sortBy on empty collection returns empty list") {
+    assertEquals(run(Mirra.all(World.items).sortBy(_.value)), List.empty[Item])
+  }
+
+  // ------------------------------------------------------------------
+  // minBy / maxBy
+  // ------------------------------------------------------------------
+
+  test("minBy returns the element with the smallest key") {
+    val state = World(List(b, a, c), Nil)
+    assertEquals(run(Mirra.all(World.items).minBy(_.value), state), Some(a))
+  }
+
+  test("maxBy returns the element with the largest key") {
+    val state = World(List(a, c, b), Nil)
+    assertEquals(run(Mirra.all(World.items).maxBy(_.value), state), Some(c))
+  }
+
+  test("minBy returns None on empty collection") {
+    assertEquals(run(Mirra.all(World.items).minBy(_.value)), None)
+  }
+
+  test("maxBy returns None on empty collection") {
+    assertEquals(run(Mirra.all(World.items).maxBy(_.value)), None)
+  }
+
+  // ------------------------------------------------------------------
+  // sumBy
+  // ------------------------------------------------------------------
+
+  test("sumBy sums extracted numeric values") {
+    val state = World(List(a, b, c), Nil)
+    assertEquals(run(Mirra.all(World.items).sumBy(_.value), state), 60)
+  }
+
+  test("sumBy returns zero on empty collection") {
+    assertEquals(run(Mirra.all(World.items).sumBy(_.value)), 0)
+  }
+
+  // ------------------------------------------------------------------
+  // groupBy
+  // ------------------------------------------------------------------
+
+  test("groupBy partitions elements by key") {
+    val d = Item(4, "a", 40)
+    val state = World(List(a, b, c, d), Nil)
+    val result = run(Mirra.all(World.items).groupBy(_.name), state)
+    assertEquals(result, Map("a" -> List(a, d), "b" -> List(b), "c" -> List(c)))
+  }
+
+  test("groupBy on empty collection returns empty map") {
+    assertEquals(run(Mirra.all(World.items).groupBy(_.name)), Map.empty[String, List[Item]])
+  }
 }


### PR DESCRIPTION
Uses cats.Order for ordering operations and Foldable#minimumByOption / maximumByOption for min/max; 14 new tests covering all operators and empty-collection edge cases.