### PR TITLE
Fix Maven Central publishing: add publishTo and update workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,4 +27,4 @@ jobs:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           PGP_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run: sbt +publishSigned sonatypeBundleRelease
+        run: sbt "+publishSigned; sonatypeCentralUpload"

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,8 @@ ThisBuild / developers           := List(
 )
 ThisBuild / sonatypeCredentialHost := "central.sonatype.com"
 ThisBuild / sonatypeRepository     := "https://central.sonatype.com/api/v1/publisher"
+ThisBuild / publishTo              := sonatypePublishToBundle.value
+ThisBuild / versionScheme          := Some("early-semver")
 
 val core =
   project.in(file("core"))


### PR DESCRIPTION
- Add publishTo := sonatypePublishToBundle.value (root cause of "Repository not specified" error)
- Add versionScheme to silence sbt warning
- Replace sonatypeBundleRelease with sonatypeCentralUpload for new Central Portal API