### PR TITLE
Suppress unresolved-link warnings from rendering inline in code blocks

### DIFF
--- a/project/MirraSitePlugin.scala
+++ b/project/MirraSitePlugin.scala
@@ -17,13 +17,12 @@ object MirraSitePlugin extends AutoPlugin {
   override def projectSettings: Seq[Setting[_]] = Seq(
     tlSitePublishBranch := Some("master"),
     // Laika 1.3.x parses type-parameter brackets like [Person] / [F[_]] in
-    // code blocks as reference-style link IDs. Raise the fail threshold so
-    // only truly Fatal messages abort the build; link-reference issues are
-    // still rendered as warnings.
+    // code blocks as reference-style link IDs. Only Fatal messages abort the
+    // build; render only Error+ inline so link-reference warnings are suppressed.
     laikaConfig := LaikaConfig.defaults.withMessageFilters(
       MessageFilters.custom(
         failOn = MessageFilter.Fatal,
-        render = MessageFilter.Warning,
+        render = MessageFilter.Error,
       )
     ),
     tlSiteHelium := {


### PR DESCRIPTION
Laika 1.3.x parses type-parameter brackets (e.g. F[_], List[Person]) inside code blocks as reference-style link IDs and emits warnings. With render = MessageFilter.Warning those warnings were injected as inline text into the rendered code blocks, producing output like "Funresolved link id reference: _[_]". Raising the render threshold to MessageFilter.Error keeps the warnings silent in the HTML output while still aborting on Fatal messages.