### PR TITLE
Add upsertWith/upsertManyWith/upsertManyWith_ combinators

### DIFF
--- a/core/src/main/scala/mirra/Mirra.scala
+++ b/core/src/main/scala/mirra/Mirra.scala
@@ -134,6 +134,48 @@ object Mirra {
       } yield toInsert ++ updated
     }
 
+  /** Upserts a single `item` into the collection at `at` using a binary merge
+   *  function.
+   *
+   *  When a conflict is detected via `conflict`, `merge(existing, incoming)` is
+   *  called so callers can choose which fields from the incoming record to apply
+   *  — analogous to Postgres `ON CONFLICT DO UPDATE SET col = EXCLUDED.col`.
+   *  When no conflict exists the item is appended unchanged.
+   *  Returns the number of affected rows (always `1L`).
+   *
+   *  @see [[upsertManyWith]] for bulk variant. */
+  def upsertWith[D, A, B](at: Lens[D, List[A]])(conflict: A => B, merge: (A, A) => A, item: A): Mirra[D, Long] =
+    upsertManyWith(at)(conflict, merge, List(item))
+
+  /** Upserts `items` into the collection at `at` using a binary merge function.
+   *
+   *  On conflict `merge(existing, incoming)` selects which fields to keep,
+   *  mirroring Postgres `ON CONFLICT DO UPDATE SET …`.
+   *  Returns the total number of affected rows (inserts + updates).
+   *
+   *  @see [[upsertManyWith_]] to also receive the affected items. */
+  def upsertManyWith[D, A, B](at: Lens[D, List[A]])(conflict: A => B, merge: (A, A) => A, items: List[A]): Mirra[D, Long] =
+    upsertManyWith_(at)(conflict, merge, items).size
+
+  /** Upserts `items` into the collection at `at` using a binary merge function
+   *  and returns the affected items (newly inserted items and post-merge
+   *  versions of updated items).
+   *
+   *  On conflict `merge(existing, incoming)` selects which fields to keep,
+   *  mirroring Postgres `ON CONFLICT DO UPDATE SET …`. */
+  def upsertManyWith_[D, A, B](at: Lens[D, List[A]])(conflict: A => B, merge: (A, A) => A, items: List[A]): Mirra[D, List[A]] =
+    Mirra {
+      for {
+        elements       <- State.get[D]
+        incomingByKey   = items.map(x => conflict(x) -> x).toMap
+        (toUpdate, notToUpdate) = at.get(elements).partition(x => incomingByKey.contains(conflict(x)))
+        updated         = toUpdate.map(x => merge(x, incomingByKey(conflict(x))))
+        conflictKeys    = toUpdate.map(conflict).toSet
+        toInsert        = items.filterNot(x => conflictKeys.contains(conflict(x)))
+        _              <- State.modify[D](s => at.modify(_ => updated ++ notToUpdate ++ toInsert)(s))
+      } yield toInsert ++ updated
+    }
+
   /** [[cats.Monad]] instance for `Mirra[D, *]`, enabling `for`-comprehension
    *  sequencing of operations over the same domain `D`. */
   implicit def monad[D]: Monad[[A] =>> Mirra[D, A]] = new (Monad[[A] =>> Mirra[D, A]]) {

--- a/core/src/test/scala/mirra/MirraSpec.scala
+++ b/core/src/test/scala/mirra/MirraSpec.scala
@@ -242,6 +242,81 @@ class MirraSpec extends FunSuite with MirraSyntax {
   }
 
   // ------------------------------------------------------------------
+  // upsertWith / upsertManyWith / upsertManyWith_
+  // ------------------------------------------------------------------
+
+  test("upsertWith inserts a new item when no conflict exists") {
+    assertEquals(run(Mirra.upsertWith(World.items)(_.id, (_, inc) => inc, a)), 1L)
+  }
+
+  test("upsertWith merges only selected fields on conflict") {
+    // existing: a = Item(1, "a", 10); incoming has same id but new name and value
+    val incoming = Item(1, "updated", 99)
+    val state = World(List(a, b), Nil)
+    // merge: keep existing value, take incoming name — like SET name = EXCLUDED.name
+    val result = run(
+      for {
+        _ <- Mirra.upsertWith(World.items)(_.id, (ex, inc) => ex.copy(name = inc.name), incoming)
+        xs <- Mirra.all(World.items)
+      } yield xs,
+      state
+    )
+    assertEquals(result.find(_.id == 1).map(_.name), Some("updated"))
+    assertEquals(result.find(_.id == 1).map(_.value), Some(10)) // value untouched
+  }
+
+  test("upsertWith does not duplicate on conflict") {
+    val state = World(List(a), Nil)
+    val result = run(
+      for {
+        _ <- Mirra.upsertWith(World.items)(_.id, (_, inc) => inc, a)
+        xs <- Mirra.all(World.items)
+      } yield xs,
+      state
+    )
+    assertEquals(result.length, 1)
+  }
+
+  test("upsertManyWith inserts all new items") {
+    assertEquals(run(Mirra.upsertManyWith(World.items)(_.id, (_, inc) => inc, List(a, b, c))), 3L)
+  }
+
+  test("upsertManyWith merges conflicts and inserts new items") {
+    val state = World(List(a), Nil)
+    // incoming a has same id; merge keeps existing value, takes incoming name
+    val incomingA = Item(1, "merged", 99)
+    val result = run(
+      for {
+        _ <- Mirra.upsertManyWith(World.items)(_.id, (ex, inc) => ex.copy(name = inc.name), List(incomingA, b))
+        xs <- Mirra.all(World.items)
+      } yield xs,
+      state
+    )
+    assertEquals(result.length, 2)
+    assertEquals(result.find(_.id == 1).map(_.name), Some("merged"))
+    assertEquals(result.find(_.id == 1).map(_.value), Some(10)) // value untouched
+    assertEquals(result.find(_.id == 2), Some(b))
+  }
+
+  test("upsertManyWith_ returns inserted items and post-merge updated items") {
+    val state = World(List(a), Nil)
+    val incomingA = Item(1, "merged", 99)
+    // a conflicts (updated), b is new (inserted)
+    val result = run(Mirra.upsertManyWith_(World.items)(_.id, (_, inc) => inc, List(incomingA, b)), state)
+    assertEquals(result.map(_.id).toSet, Set(1, 2))
+    assertEquals(result.find(_.id == 1).map(_.name), Some("merged"))
+  }
+
+  test("upsertManyWith_ returns post-merge state, not pre-merge state") {
+    val state = World(List(a), Nil)
+    // merge: take incoming name but keep existing value
+    val incoming = Item(1, "new-name", 999)
+    val result = run(Mirra.upsertManyWith_(World.items)(_.id, (ex, inc) => ex.copy(name = inc.name), List(incoming)), state)
+    assertEquals(result.find(_.id == 1).map(_.name), Some("new-name"))
+    assertEquals(result.find(_.id == 1).map(_.value), Some(10))
+  }
+
+  // ------------------------------------------------------------------
   // Monad laws / composition
   // ------------------------------------------------------------------
 


### PR DESCRIPTION
Mirrors Postgres ON CONFLICT DO UPDATE SET col = EXCLUDED.col: the merge function receives (existing, incoming) so callers can selectively apply fields from the incoming record rather than replacing the whole record.