### PR TITLE
Add composing-repositories documentation page

### DIFF
--- a/core/src/main/scala/mirra/Mirra.scala
+++ b/core/src/main/scala/mirra/Mirra.scala
@@ -134,6 +134,48 @@ object Mirra {
       } yield toInsert ++ updated
     }
 
+  /** Upserts a single `item` into the collection at `at` using a binary merge
+   *  function.
+   *
+   *  When a conflict is detected via `conflict`, `merge(existing, incoming)` is
+   *  called so callers can choose which fields from the incoming record to apply
+   *  — analogous to Postgres `ON CONFLICT DO UPDATE SET col = EXCLUDED.col`.
+   *  When no conflict exists the item is appended unchanged.
+   *  Returns the number of affected rows (always `1L`).
+   *
+   *  @see [[upsertManyWith]] for bulk variant. */
+  def upsertWith[D, A, B](at: Lens[D, List[A]])(conflict: A => B, merge: (A, A) => A, item: A): Mirra[D, Long] =
+    upsertManyWith(at)(conflict, merge, List(item))
+
+  /** Upserts `items` into the collection at `at` using a binary merge function.
+   *
+   *  On conflict `merge(existing, incoming)` selects which fields to keep,
+   *  mirroring Postgres `ON CONFLICT DO UPDATE SET …`.
+   *  Returns the total number of affected rows (inserts + updates).
+   *
+   *  @see [[upsertManyWith_]] to also receive the affected items. */
+  def upsertManyWith[D, A, B](at: Lens[D, List[A]])(conflict: A => B, merge: (A, A) => A, items: List[A]): Mirra[D, Long] =
+    upsertManyWith_(at)(conflict, merge, items).size
+
+  /** Upserts `items` into the collection at `at` using a binary merge function
+   *  and returns the affected items (newly inserted items and post-merge
+   *  versions of updated items).
+   *
+   *  On conflict `merge(existing, incoming)` selects which fields to keep,
+   *  mirroring Postgres `ON CONFLICT DO UPDATE SET …`. */
+  def upsertManyWith_[D, A, B](at: Lens[D, List[A]])(conflict: A => B, merge: (A, A) => A, items: List[A]): Mirra[D, List[A]] =
+    Mirra {
+      for {
+        elements       <- State.get[D]
+        incomingByKey   = items.map(x => conflict(x) -> x).toMap
+        (toUpdate, notToUpdate) = at.get(elements).partition(x => incomingByKey.contains(conflict(x)))
+        updated         = toUpdate.map(x => merge(x, incomingByKey(conflict(x))))
+        conflictKeys    = toUpdate.map(conflict).toSet
+        toInsert        = items.filterNot(x => conflictKeys.contains(conflict(x)))
+        _              <- State.modify[D](s => at.modify(_ => updated ++ notToUpdate ++ toInsert)(s))
+      } yield toInsert ++ updated
+    }
+
   /** [[cats.Monad]] instance for `Mirra[D, *]`, enabling `for`-comprehension
    *  sequencing of operations over the same domain `D`. */
   implicit def monad[D]: Monad[[A] =>> Mirra[D, A]] = new (Monad[[A] =>> Mirra[D, A]]) {

--- a/core/src/test/scala/mirra/MirraSpec.scala
+++ b/core/src/test/scala/mirra/MirraSpec.scala
@@ -242,6 +242,81 @@ class MirraSpec extends FunSuite with MirraSyntax {
   }
 
   // ------------------------------------------------------------------
+  // upsertWith / upsertManyWith / upsertManyWith_
+  // ------------------------------------------------------------------
+
+  test("upsertWith inserts a new item when no conflict exists") {
+    assertEquals(run(Mirra.upsertWith(World.items)(_.id, (_, inc) => inc, a)), 1L)
+  }
+
+  test("upsertWith merges only selected fields on conflict") {
+    // existing: a = Item(1, "a", 10); incoming has same id but new name and value
+    val incoming = Item(1, "updated", 99)
+    val state = World(List(a, b), Nil)
+    // merge: keep existing value, take incoming name — like SET name = EXCLUDED.name
+    val result = run(
+      for {
+        _ <- Mirra.upsertWith(World.items)(_.id, (ex, inc) => ex.copy(name = inc.name), incoming)
+        xs <- Mirra.all(World.items)
+      } yield xs,
+      state
+    )
+    assertEquals(result.find(_.id == 1).map(_.name), Some("updated"))
+    assertEquals(result.find(_.id == 1).map(_.value), Some(10)) // value untouched
+  }
+
+  test("upsertWith does not duplicate on conflict") {
+    val state = World(List(a), Nil)
+    val result = run(
+      for {
+        _ <- Mirra.upsertWith(World.items)(_.id, (_, inc) => inc, a)
+        xs <- Mirra.all(World.items)
+      } yield xs,
+      state
+    )
+    assertEquals(result.length, 1)
+  }
+
+  test("upsertManyWith inserts all new items") {
+    assertEquals(run(Mirra.upsertManyWith(World.items)(_.id, (_, inc) => inc, List(a, b, c))), 3L)
+  }
+
+  test("upsertManyWith merges conflicts and inserts new items") {
+    val state = World(List(a), Nil)
+    // incoming a has same id; merge keeps existing value, takes incoming name
+    val incomingA = Item(1, "merged", 99)
+    val result = run(
+      for {
+        _ <- Mirra.upsertManyWith(World.items)(_.id, (ex, inc) => ex.copy(name = inc.name), List(incomingA, b))
+        xs <- Mirra.all(World.items)
+      } yield xs,
+      state
+    )
+    assertEquals(result.length, 2)
+    assertEquals(result.find(_.id == 1).map(_.name), Some("merged"))
+    assertEquals(result.find(_.id == 1).map(_.value), Some(10)) // value untouched
+    assertEquals(result.find(_.id == 2), Some(b))
+  }
+
+  test("upsertManyWith_ returns inserted items and post-merge updated items") {
+    val state = World(List(a), Nil)
+    val incomingA = Item(1, "merged", 99)
+    // a conflicts (updated), b is new (inserted)
+    val result = run(Mirra.upsertManyWith_(World.items)(_.id, (_, inc) => inc, List(incomingA, b)), state)
+    assertEquals(result.map(_.id).toSet, Set(1, 2))
+    assertEquals(result.find(_.id == 1).map(_.name), Some("merged"))
+  }
+
+  test("upsertManyWith_ returns post-merge state, not pre-merge state") {
+    val state = World(List(a), Nil)
+    // merge: take incoming name but keep existing value
+    val incoming = Item(1, "new-name", 999)
+    val result = run(Mirra.upsertManyWith_(World.items)(_.id, (ex, inc) => ex.copy(name = inc.name), List(incoming)), state)
+    assertEquals(result.find(_.id == 1).map(_.name), Some("new-name"))
+    assertEquals(result.find(_.id == 1).map(_.value), Some(10))
+  }
+
+  // ------------------------------------------------------------------
   // Monad laws / composition
   // ------------------------------------------------------------------
 

--- a/docs/src/main/laika/combinators.md
+++ b/docs/src/main/laika/combinators.md
@@ -1,0 +1,307 @@
+# Combinators Reference
+
+`Mirra` provides two complementary layers:
+
+- **State operations** (`Mirra` companion object) — modify in-memory state: insert, update, delete, upsert, etc.
+- **Query syntax** (`MirraSyntax`) — transform and aggregate the *result* of a `Mirra[D, List[A]]` program: filter, sort, join, paginate.
+
+All state operations take a Monocle `Lens` that targets the collection to operate on. Query syntax methods are extension methods on `Mirra[D, F[A]]` — mix `MirraSyntax` into your suite or import it:
+
+```scala
+class MySpec extends MirraSuite[IO, MyAlg] with MirraSyntax { ... }
+```
+
+---
+
+```scala mdoc:invisible
+import cats.implicits.*
+import mirra.{Mirra, MirraSyntax}
+import monocle.Focus
+
+case class Person(id: Int, name: String, age: Int)
+case class Order(id: Int, personId: Int, amount: Int)
+case class Universe(persons: List[Person], orders: List[Order])
+object Universe { val zero: Universe = Universe(Nil, Nil) }
+
+object S extends MirraSyntax
+import S.*
+
+def run[A](prog: Mirra[Universe, A], state: Universe = Universe.zero): A = prog.run(state)
+
+val alice = Person(1, "Alice", 30)
+val bob   = Person(2, "Bob",   25)
+val carol = Person(3, "Carol", 35)
+val three = Universe(List(alice, bob, carol), Nil)
+```
+
+## State operations
+
+### `unit` and `succeed`
+
+`unit` produces `Unit` without touching state — useful to model a no-op such as a schema-creation step that is meaningless in memory. `succeed` lifts any pure value.
+
+```scala mdoc
+run(Mirra.unit[Universe])
+run(Mirra.succeed[Universe, String]("hello"))
+```
+
+### `all`
+
+Returns every element of the targeted collection without modifying state.
+
+```scala mdoc
+run(Mirra.all(Focus[Universe](_.persons)), three)
+```
+
+### `insert` / `insertMany` / `insertMany_`
+
+`insert` appends one element; `insertMany` appends a list. Both return the number of rows inserted as `Long`. The `_` suffix variant returns the inserted elements instead of the count.
+
+```scala mdoc
+run(Mirra.insert(Focus[Universe](_.persons))(alice))
+run(Mirra.insertMany(Focus[Universe](_.persons))(List(alice, bob)))
+run(Mirra.insertMany_(Focus[Universe](_.persons))(List(alice, bob)))
+```
+
+State accumulates across steps in a `for`-comprehension:
+
+```scala mdoc
+run(
+  for {
+    _ <- Mirra.insert(Focus[Universe](_.persons))(alice)
+    _ <- Mirra.insert(Focus[Universe](_.persons))(bob)
+    r <- Mirra.all(Focus[Universe](_.persons))
+  } yield r
+)
+```
+
+### `update` / `update_`
+
+`update(lens)(filter, transform)` applies `transform` to every element satisfying `filter` and returns the count of affected rows. `update_` returns the **pre-transformation** elements instead.
+
+```scala mdoc
+run(
+  for {
+    n <- Mirra.update(Focus[Universe](_.persons))(_.age > 28, _.copy(age = 99))
+    r <- Mirra.all(Focus[Universe](_.persons))
+  } yield (n, r),
+  three
+)
+```
+
+### `delete` / `delete_`
+
+`delete(lens)(filter)` removes every element satisfying `filter` and returns the count. `delete_` returns the removed elements.
+
+```scala mdoc
+run(
+  for {
+    removed   <- Mirra.delete_(Focus[Universe](_.persons))(_.age < 28)
+    remaining <- Mirra.all(Focus[Universe](_.persons))
+  } yield (removed, remaining),
+  three
+)
+```
+
+### `truncate`
+
+Clears the entire collection and returns the number of elements that existed before.
+
+```scala mdoc
+run(Mirra.truncate(Focus[Universe](_.persons)), three)
+```
+
+### `upsert` / `upsertMany`
+
+Insert-or-replace based on a conflict key. When an existing element shares the same key, the `update: A => A` function is applied to it; otherwise the item is appended. Returns the number of affected rows.
+
+```scala mdoc
+// Replace alice's name on conflict (same id)
+val renamed = alice.copy(name = "Alicia")
+run(
+  for {
+    _ <- Mirra.upsert(Focus[Universe](_.persons))(_.id, _ => renamed, alice)
+    r <- Mirra.all(Focus[Universe](_.persons))
+  } yield r,
+  three
+)
+```
+
+`upsertMany` does the same for a list; `upsertMany_` returns the affected elements.
+
+### `upsertWith` / `upsertManyWith`
+
+Like `upsert` but uses a binary merge function `(existing, incoming) => A`, so you can choose which fields from the incoming record to apply — mirroring Postgres `ON CONFLICT DO UPDATE SET col = EXCLUDED.col`. Returns the number of affected rows.
+
+```scala mdoc
+// Keep existing age, take the incoming name
+val incoming = Person(1, "Alicia", 99)
+run(
+  for {
+    _ <- Mirra.upsertWith(Focus[Universe](_.persons))(_.id, (ex, inc) => ex.copy(name = inc.name), incoming)
+    r <- Mirra.all(Focus[Universe](_.persons))
+  } yield r,
+  three
+)
+```
+
+`upsertManyWith` handles a list; `upsertManyWith_` additionally returns the post-merge elements.
+
+---
+
+## Query syntax
+
+Extension methods on `Mirra[D, F[A]]` from `MirraSyntax`. They transform or aggregate the *result* of a program without issuing additional state reads — the state is already read by the preceding `all` (or any other state operation returning a collection).
+
+### `filter`
+
+Keeps only elements satisfying a predicate.
+
+```scala mdoc
+run(Mirra.all(Focus[Universe](_.persons)).filter(_.age > 28), three)
+```
+
+### `collect`
+
+Applies a partial function and discards non-matches — like `filter` + `select` in one step.
+
+```scala mdoc
+run(
+  Mirra.all(Focus[Universe](_.persons)).collect { case p if p.age > 28 => p.name },
+  three
+)
+```
+
+### `headOption`
+
+Returns the first element of the result, or `None` if empty.
+
+```scala mdoc
+run(Mirra.all(Focus[Universe](_.persons)).headOption, three)
+run(Mirra.all(Focus[Universe](_.persons)).filter(_.age > 99).headOption, three)
+```
+
+### `select`
+
+Maps every element — the SQL `SELECT` equivalent.
+
+```scala mdoc
+run(Mirra.all(Focus[Universe](_.persons)).select(_.name), three)
+```
+
+### `size`
+
+Returns the number of elements.
+
+```scala mdoc
+run(Mirra.all(Focus[Universe](_.persons)).size, three)
+```
+
+### `sumBy`
+
+Sums a numeric field across all elements.
+
+```scala mdoc
+run(Mirra.all(Focus[Universe](_.persons)).sumBy(_.age), three)
+```
+
+### `minBy` / `maxBy`
+
+Returns the element with the smallest or largest value of a key, or `None` if empty.
+
+```scala mdoc
+run(Mirra.all(Focus[Universe](_.persons)).minBy(_.age), three)
+run(Mirra.all(Focus[Universe](_.persons)).maxBy(_.age), three)
+```
+
+### `reduced`
+
+Folds all elements using their `cats.Monoid` instance. Works naturally for strings, numbers, etc.
+
+```scala mdoc
+run(Mirra.all(Focus[Universe](_.persons)).select(_.name).reduced, three)
+```
+
+### `groupBy`
+
+Partitions results into a `Map` keyed by the output of a function.
+
+```scala mdoc
+val dave = Person(4, "Dave", 30)
+val four = Universe(List(alice, bob, carol, dave), Nil)
+run(Mirra.all(Focus[Universe](_.persons)).groupBy(_.age), four)
+```
+
+### `sortBy` / `sortByDesc`
+
+Sorts results ascending or descending by a key. Requires a `cats.Order` instance for the key type, which `cats.implicits.*` provides for all primitives.
+
+```scala mdoc
+run(Mirra.all(Focus[Universe](_.persons)).sortBy(_.age), three)
+run(Mirra.all(Focus[Universe](_.persons)).sortByDesc(_.age), three)
+```
+
+### `innerJoin` / `leftJoin` / `rightJoin`
+
+Joins the current result collection with another collection read from the universe via a lens. The join predicate is `(A, B) => Boolean`.
+
+```scala mdoc
+val withOrders = Universe(List(alice, bob, carol), List(Order(1, 1, 100), Order(2, 2, 200)))
+
+// inner join: only persons who have a matching order
+run(
+  Mirra.all(Focus[Universe](_.persons))
+    .innerJoin(Focus[Universe](_.orders))((p, o) => p.id == o.personId),
+  withOrders
+)
+```
+
+```scala mdoc
+// left join: all persons, paired with their order if one exists
+run(
+  Mirra.all(Focus[Universe](_.persons))
+    .leftJoin(Focus[Universe](_.orders))((p, o) => p.id == o.personId),
+  withOrders
+)
+```
+
+```scala mdoc
+// right join: all orders, paired with their person if one matches
+run(
+  Mirra.all(Focus[Universe](_.persons))
+    .rightJoin(Focus[Universe](_.orders))((p, o) => p.id == o.personId),
+  withOrders
+)
+```
+
+### `limit` / `offset`
+
+`limit(n)` returns at most `n` elements from the start of the result; `offset(n)` skips the first `n`. Chain them to implement pagination.
+
+```scala mdoc
+// Page 2 of size 1, sorted by age ascending
+run(
+  Mirra.all(Focus[Universe](_.persons))
+    .sortBy(_.age)
+    .offset(1)
+    .limit(1),
+  three
+)
+```
+
+---
+
+## Combining operations
+
+Because `Mirra[D, *]` is a `Monad`, you can sequence any number of operations in a `for`-comprehension. State modifications accumulate across steps:
+
+```scala mdoc
+run(
+  for {
+    _      <- Mirra.insertMany(Focus[Universe](_.persons))(List(alice, bob, carol))
+    _      <- Mirra.delete(Focus[Universe](_.persons))(_.age < 28)
+    _      <- Mirra.upsertWith(Focus[Universe](_.persons))(_.id, (ex, inc) => ex.copy(name = inc.name), Person(1, "Alicia", 0))
+    result <- Mirra.all(Focus[Universe](_.persons)).sortBy(_.age)
+  } yield result
+)
+```

--- a/docs/src/main/laika/composing-repositories.md
+++ b/docs/src/main/laika/composing-repositories.md
@@ -1,0 +1,145 @@
+# Composing Repositories
+
+Real applications usually have more than one repository. Mirra handles multi-repository system under tests naturally: wrap the individual repositories in a single higher-kinded trait, derive `FunctorK` and `SemigroupalK` for it, and pass it to `MirraSuite` or `MirraZIOSuite` as the `Alg` type parameter.
+
+## Requirements
+
+`SystemUnderTest` uses `SemigroupalK` to run both the real implementation and the in-memory model through the same program simultaneously, and `FunctorK` to adapt effect types. For the composed trait's instances to be derivable by cats-tagless, **every sub-repository must already have `FunctorK` and `SemigroupalK` instances** — cats-tagless delegates to them when deriving instances for the outer trait.
+
+## 1. Give each sub-repository FunctorK and SemigroupalK
+
+Every repository in the composition needs both instances in its companion object. cats-tagless derives them automatically:
+
+```scala mdoc
+import cats.tagless.{Derive, FunctorK, SemigroupalK}
+import java.util.UUID
+
+final case class Person(id: UUID, name: String, age: Int)
+final case class Organization(id: UUID, name: String)
+
+trait PersonRepository[F[_]] {
+  def create: F[Unit]
+  def insertMany(persons: List[Person]): F[Long]
+  def listAll(): F[List[Person]]
+}
+
+object PersonRepository {
+  implicit val functorK: FunctorK[PersonRepository]         = Derive.functorK
+  implicit val semigroupalK: SemigroupalK[PersonRepository] = Derive.semigroupalK
+}
+
+trait OrganizationRepository[F[_]] {
+  def create: F[Unit]
+  def insertMany(orgs: List[Organization]): F[Long]
+  def listAll(): F[List[Organization]]
+}
+
+object OrganizationRepository {
+  implicit val functorK: FunctorK[OrganizationRepository]         = Derive.functorK
+  implicit val semigroupalK: SemigroupalK[OrganizationRepository] = Derive.semigroupalK
+}
+```
+
+## 2. Define the composed algebra
+
+Create a trait whose methods return the individual repositories parameterised by the same `F[_]`, then derive `FunctorK` and `SemigroupalK` for it:
+
+```scala mdoc
+trait Repositories[F[_]] {
+  def persons: PersonRepository[F]
+  def organizations: OrganizationRepository[F]
+}
+
+object Repositories {
+  implicit val functorK: FunctorK[Repositories]         = Derive.functorK
+  implicit val semigroupalK: SemigroupalK[Repositories] = Derive.semigroupalK
+}
+```
+
+`Derive.functorK` produces `FunctorK[Repositories]` by applying `FunctorK[PersonRepository].mapK` and `FunctorK[OrganizationRepository].mapK` to the respective fields. `Derive.semigroupalK` does the same by calling `SemigroupalK[PersonRepository].productK` and `SemigroupalK[OrganizationRepository].productK`. This is why the sub-repository instances are required: without them, the macro has no way to transform or pair the nested algebras.
+
+## 3. Expand the universe
+
+Each entity collection lives in the shared `Universe` state type. Add a field for every repository:
+
+```scala mdoc
+import mirra.Mirra
+import monocle.Focus
+
+final case class Universe(
+  persons: List[Person],
+  organizations: List[Organization],
+)
+
+object Universe {
+  def zero: Universe = Universe(Nil, Nil)
+}
+```
+
+## 4. Implement the Mirra model
+
+Implement `Repositories[[A] =>> Mirra[Universe, A]]`. Each method returns an anonymous implementation of the corresponding sub-repository, targeting its own lens into `Universe`:
+
+```scala mdoc
+object MirraRepositories extends Repositories[[A] =>> Mirra[Universe, A]] {
+  def persons: PersonRepository[[A] =>> Mirra[Universe, A]] =
+    new PersonRepository[[A] =>> Mirra[Universe, A]] {
+      def create: Mirra[Universe, Unit] =
+        Mirra.unit
+      def insertMany(ps: List[Person]): Mirra[Universe, Long] =
+        Mirra.insertMany(Focus[Universe](_.persons))(ps)
+      def listAll(): Mirra[Universe, List[Person]] =
+        Mirra.all(Focus[Universe](_.persons))
+    }
+
+  def organizations: OrganizationRepository[[A] =>> Mirra[Universe, A]] =
+    new OrganizationRepository[[A] =>> Mirra[Universe, A]] {
+      def create: Mirra[Universe, Unit] =
+        Mirra.unit
+      def insertMany(orgs: List[Organization]): Mirra[Universe, Long] =
+        Mirra.insertMany(Focus[Universe](_.organizations))(orgs)
+      def listAll(): Mirra[Universe, List[Organization]] =
+        Mirra.all(Focus[Universe](_.organizations))
+    }
+}
+```
+
+## 5. Wire into MirraSuite
+
+Set the `Alg` type parameter to `Repositories`. The `bootstrapSystemUnderTest` method receives a real `Repositories[TransactionEffect]` implementation alongside `MirraRepositories`, wired into a single `SystemUnderTest`. Inside `assertMirroring`, access each repository through the paired interpreter:
+
+```scala
+class RepositoriesSpec extends MirraSuite[IO, Repositories] {
+
+  override type BootstrapContext     = Containers
+  override type MirraState           = Universe
+  override type TransactionEffect[A] = ConnectionIO[A]
+
+  override def bootstrapSystemUnderTest(c: Containers): Resource[IO, SystemUnderTest] =
+    Resource.pure(new SystemUnderTest(
+      Universe.zero,
+      DoobieRepositories,  // real implementations
+      MirraRepositories,   // in-memory model
+      DoobieSupport.rollbackTrans[IO](...)
+    ))
+
+  test("insert persons and orgs, then list both") {
+    PropF.forAllF { (persons: List[Person], orgs: List[Organization]) =>
+      withContainers { c =>
+        assertMirroring(c) { x =>
+          for {
+            _ <- x.persons.create
+            _ <- x.organizations.create
+            _ <- x.persons.insertMany(persons)
+            _ <- x.organizations.insertMany(orgs)
+            p <- x.persons.listAll()
+            o <- x.organizations.listAll()
+          } yield (p, o)
+        }
+      }
+    }
+  }
+}
+```
+
+The real `DoobieRepositories` implementation follows the same pattern as the single-repository Doobie examples — implement each sub-repository against the database and assemble them into the composed trait.

--- a/docs/src/main/laika/directory.conf
+++ b/docs/src/main/laika/directory.conf
@@ -3,6 +3,7 @@ laika.title = "mirra"
 laika.navigationOrder = [
   index.md
   getting-started.md
+  composing-repositories.md
   doobie.md
   skunk.md
   munit.md

--- a/docs/src/main/laika/directory.conf
+++ b/docs/src/main/laika/directory.conf
@@ -3,6 +3,7 @@ laika.title = "mirra"
 laika.navigationOrder = [
   index.md
   getting-started.md
+  combinators.md
   composing-repositories.md
   doobie.md
   skunk.md

--- a/docs/src/main/laika/getting-started.md
+++ b/docs/src/main/laika/getting-started.md
@@ -58,6 +58,7 @@ object MirraPersonRepository extends PersonRepository[[A] =>> Mirra[Universe, A]
 
 With the algebra and model in place, wire in a real database backend and a test framework integration:
 
+- [Composing repositories](composing-repositories.md) — test multiple repositories together in a single `SystemUnderTest`
 - [Doobie](doobie.md) — `ConnectionIO`-based backend + munit example
 - [Skunk](skunk.md) — `Kleisli[F, Session[F], *]`-based backend
 - [munit + cats-effect](munit.md) — property-test with `MirraSuite`

--- a/docs/src/main/laika/getting-started.md
+++ b/docs/src/main/laika/getting-started.md
@@ -58,6 +58,7 @@ object MirraPersonRepository extends PersonRepository[[A] =>> Mirra[Universe, A]
 
 With the algebra and model in place, wire in a real database backend and a test framework integration:
 
+- [Combinators reference](combinators.md) — every `Mirra` operator and `MirraSyntax` extension with examples
 - [Composing repositories](composing-repositories.md) — test multiple repositories together in a single `SystemUnderTest`
 - [Doobie](doobie.md) — `ConnectionIO`-based backend + munit example
 - [Skunk](skunk.md) — `Kleisli[F, Session[F], *]`-based backend


### PR DESCRIPTION
Documents how to combine multiple repositories into a single SystemUnderTest using a higher-kinded wrapper trait, with FunctorK and SemigroupalK derived via cats-tagless. Explains why sub-repository instances are required.