### PR TITLE
Add mirra-zio and mirra-cats-effect in-memory interpreter modules

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -130,7 +130,7 @@ val example =
 lazy val docs = project
   .in(file("docs"))
   .enablePlugins(MirraSitePlugin)
-  .dependsOn(core, doobie, skunk, munit, zioTest)
+  .dependsOn(core, doobie, skunk, munit, zioTest, catsEffect, zio)
   .settings(commonSettings)
   .settings(
     publish / skip := true,
@@ -140,6 +140,8 @@ lazy val docs = project
       "com.dimafeng" %% "testcontainers-scala-postgresql"  % "0.44.1",
       "com.dimafeng" %% "testcontainers-scala-munit"       % "0.44.1",
       "dev.zio"      %% "zio-interop-cats"                 % "23.1.0.3",
+      "org.typelevel" %% "munit-cats-effect"               % "2.2.0",
+      "dev.zio"      %% "zio-test"                         % "2.1.14",
     ),
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -55,6 +55,28 @@ val munit =
     )
     .dependsOn(core)
 
+val zio =
+  project.in(file("zio"))
+    .settings(commonSettings)
+    .settings(
+      name := "mirra-zio",
+      libraryDependencies ++= Seq(
+        "dev.zio" %% "zio" % "2.1.14"
+      )
+    )
+    .dependsOn(core)
+
+val catsEffect =
+  project.in(file("cats-effect"))
+    .settings(commonSettings)
+    .settings(
+      name := "mirra-cats-effect",
+      libraryDependencies ++= Seq(
+        "org.typelevel" %% "cats-effect" % "3.5.7"
+      )
+    )
+    .dependsOn(core)
+
 val zioTest =
   project.in(file("zio-test"))
     .settings(commonSettings)
@@ -121,7 +143,7 @@ def commonSettings = Seq(
 )
 
 lazy val root = (project in file("."))
-  .aggregate(core, munit, doobie, skunk, zioTest)
+  .aggregate(core, munit, doobie, skunk, zioTest, zio, catsEffect)
   .settings(
     publish / skip := true
   )

--- a/build.sbt
+++ b/build.sbt
@@ -61,8 +61,11 @@ val zio =
     .settings(
       name := "mirra-zio",
       libraryDependencies ++= Seq(
-        "dev.zio" %% "zio" % "2.1.14"
-      )
+        "dev.zio" %% "zio"          % "2.1.14",
+        "dev.zio" %% "zio-test"     % "2.1.14" % Test,
+        "dev.zio" %% "zio-test-sbt" % "2.1.14" % Test,
+      ),
+      testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
     )
     .dependsOn(core)
 
@@ -72,7 +75,9 @@ val catsEffect =
     .settings(
       name := "mirra-cats-effect",
       libraryDependencies ++= Seq(
-        "org.typelevel" %% "cats-effect" % "3.5.7"
+        "org.typelevel" %% "cats-effect"       % "3.5.7",
+        "org.scalameta" %% "munit"             % "1.3.0"   % Test,
+        "org.typelevel" %% "munit-cats-effect" % "2.2.0"   % Test,
       )
     )
     .dependsOn(core)

--- a/cats-effect/src/main/scala/mirra/MirraCatsEffect.scala
+++ b/cats-effect/src/main/scala/mirra/MirraCatsEffect.scala
@@ -1,0 +1,28 @@
+package mirra
+
+import cats.effect.{Ref, Sync}
+import cats.tagless.FunctorK
+import cats.~>
+
+/** Constructs an in-memory `Alg[F]` backed by a `Ref[D]`.
+  *
+  * Each algebra method executes the underlying `State[D, A]` atomically
+  * against a `Ref[D]`, turning `Alg[[A] =>> Mirra[D, A]]` into `Alg[F]`.
+  */
+object MirraCatsEffect {
+
+  def make[F[_]: Sync, Alg[_[_]]: FunctorK, D](
+      alg: Alg[[A] =>> Mirra[D, A]],
+      initialState: D,
+  ): F[Alg[F]] =
+    Ref.of[F, D](initialState).map { ref =>
+      val nt: ([A] =>> Mirra[D, A]) ~> F = new (([A] =>> Mirra[D, A]) ~> F) {
+        def apply[A](fa: Mirra[D, A]): F[A] =
+          ref.modify { state =>
+            val (newState, result) = fa.db.run(state).value
+            (newState, result)
+          }
+      }
+      FunctorK[Alg].mapK(alg)(nt)
+    }
+}

--- a/cats-effect/src/main/scala/mirra/MirraCatsEffect.scala
+++ b/cats-effect/src/main/scala/mirra/MirraCatsEffect.scala
@@ -1,6 +1,7 @@
 package mirra
 
 import cats.effect.{Ref, Sync}
+import cats.syntax.all.*
 import cats.tagless.FunctorK
 import cats.~>
 

--- a/cats-effect/src/test/scala/mirra/MirraCatsEffectSpec.scala
+++ b/cats-effect/src/test/scala/mirra/MirraCatsEffectSpec.scala
@@ -1,0 +1,98 @@
+package mirra
+
+import cats.effect.IO
+import cats.tagless.{Derive, FunctorK}
+import monocle.Lens
+import munit.CatsEffectSuite
+
+// ---- test domain ----
+
+case class Item(id: Int, value: String)
+case class Store(items: List[Item])
+
+object Store {
+  val items: Lens[Store, List[Item]] = Lens[Store, List[Item]](_.items)(v => _.copy(items = v))
+  val empty: Store = Store(Nil)
+}
+
+trait ItemRepo[F[_]] {
+  def insert(item: Item): F[Long]
+  def getAll: F[List[Item]]
+  def delete(id: Int): F[Long]
+}
+
+object ItemRepo {
+  given FunctorK[ItemRepo] = Derive.functorK
+}
+
+object MirraItemRepo extends ItemRepo[[A] =>> Mirra[Store, A]] {
+  def insert(item: Item): Mirra[Store, Long]  = Mirra.insert(Store.items)(item)
+  def getAll: Mirra[Store, List[Item]]        = Mirra.all(Store.items)
+  def delete(id: Int): Mirra[Store, Long]     = Mirra.delete(Store.items)(_.id == id)
+}
+
+// ---- spec ----
+
+class MirraCatsEffectSpec extends CatsEffectSuite {
+
+  def mkRepo: IO[ItemRepo[IO]] =
+    MirraCatsEffect.make[IO, ItemRepo, Store](MirraItemRepo, Store.empty)
+
+  test("insert adds an item and returns 1") {
+    for {
+      repo  <- mkRepo
+      count <- repo.insert(Item(1, "foo"))
+      all   <- repo.getAll
+    } yield {
+      assertEquals(count, 1L)
+      assertEquals(all, List(Item(1, "foo")))
+    }
+  }
+
+  test("mutations are visible across subsequent calls") {
+    for {
+      repo <- mkRepo
+      _    <- repo.insert(Item(1, "a"))
+      _    <- repo.insert(Item(2, "b"))
+      all  <- repo.getAll
+    } yield assertEquals(all, List(Item(1, "a"), Item(2, "b")))
+  }
+
+  test("delete removes matching items and returns count") {
+    for {
+      repo  <- mkRepo
+      _     <- repo.insert(Item(1, "a"))
+      _     <- repo.insert(Item(2, "b"))
+      count <- repo.delete(1)
+      all   <- repo.getAll
+    } yield {
+      assertEquals(count, 1L)
+      assertEquals(all, List(Item(2, "b")))
+    }
+  }
+
+  test("delete on absent id returns 0 and leaves state unchanged") {
+    for {
+      repo  <- mkRepo
+      _     <- repo.insert(Item(1, "a"))
+      count <- repo.delete(99)
+      all   <- repo.getAll
+    } yield {
+      assertEquals(count, 0L)
+      assertEquals(all, List(Item(1, "a")))
+    }
+  }
+
+  test("each make call produces independent state") {
+    for {
+      repo1 <- mkRepo
+      repo2 <- mkRepo
+      _     <- repo1.insert(Item(1, "a"))
+      all1  <- repo1.getAll
+      all2  <- repo2.getAll
+    } yield {
+      assertEquals(all1, List(Item(1, "a")))
+      assertEquals(all2, List.empty)
+    }
+  }
+}

--- a/docs/src/main/laika/cats-effect.md
+++ b/docs/src/main/laika/cats-effect.md
@@ -53,15 +53,11 @@ object MirraPersonRepository extends PersonRepository[[A] =>> Mirra[Universe, A]
   def listAll(): Mirra[Universe, List[Person]] =
     Mirra.all(Focus[Universe](_.persons))
 }
-```
 
-```scala mdoc:compile-only
 import cats.MonadThrow
-import cats.implicits.*
+import cats.implicits._
 
-// Service is polymorphic — no IO, no concretion
 class PersonService[F[_]: MonadThrow](repo: PersonRepository[F]) {
-
   def registerAdult(person: Person): F[Unit] =
     if (person.age < 18)
       MonadThrow[F].raiseError(new IllegalArgumentException("must be 18 or older"))
@@ -77,6 +73,7 @@ In tests, instantiate the service by wiring it to an in-memory `PersonRepository
 
 ```scala mdoc:compile-only
 import cats.effect.IO
+import cats.implicits.*
 import mirra.MirraCatsEffect
 import munit.CatsEffectSuite
 import java.util.UUID

--- a/docs/src/main/laika/cats-effect.md
+++ b/docs/src/main/laika/cats-effect.md
@@ -1,0 +1,124 @@
+# cats-effect
+
+The `cats-effect` module provides `MirraCatsEffect.make` — a factory that lifts an `Alg[[A] =>> Mirra[D, A]]` into `F[Alg[F]]` by backing it with a `cats.effect.Ref[F, D]`.
+
+```scala
+libraryDependencies += "io.github.fristi" %% "mirra-cats-effect" % "<version>"
+```
+
+## How it works
+
+`MirraCatsEffect.make` allocates a `Ref[F, D]` seeded with `initialState`, then uses `FunctorK[Alg].mapK` to rewrite every algebra method: each `Mirra[D, A]` (a `State[D, A]` under the hood) is run atomically against the ref via `Ref.modify`.
+
+```
+Alg[[A] =>> Mirra[D, A]]  +  D  →  F[Alg[F]]
+```
+
+The returned `Alg[F]` is a live, stateful interpreter. State mutations from one call are visible to subsequent calls, exactly as they would be in a real database — but entirely in-memory.
+
+## Testing services that abstract over `F[_]`
+
+The typical pattern in a cats-effect codebase is to keep business logic polymorphic:
+
+```scala mdoc:invisible
+import cats.tagless.{Derive, FunctorK, SemigroupalK}
+import java.util.UUID
+import mirra.Mirra
+import monocle.Focus
+import cats.implicits._
+
+final case class Person(id: UUID, name: String, age: Int)
+
+trait PersonRepository[F[_]] {
+  def create: F[Unit]
+  def insertMany(persons: List[Person]): F[Long]
+  def deleteWhenOlderThen(age: Long): F[Long]
+  def listAll(): F[List[Person]]
+}
+
+object PersonRepository {
+  given FunctorK[PersonRepository]     = Derive.functorK
+  given SemigroupalK[PersonRepository] = Derive.semigroupalK
+}
+
+final case class Universe(persons: List[Person])
+object Universe { def zero: Universe = Universe(Nil) }
+
+object MirraPersonRepository extends PersonRepository[[A] =>> Mirra[Universe, A]] {
+  def create: Mirra[Universe, Unit] = Mirra.unit
+  def insertMany(persons: List[Person]): Mirra[Universe, Long] =
+    Mirra.insertMany(Focus[Universe](_.persons))(persons)
+  def deleteWhenOlderThen(age: Long): Mirra[Universe, Long] =
+    Mirra.delete(Focus[Universe](_.persons))(_.age > age)
+  def listAll(): Mirra[Universe, List[Person]] =
+    Mirra.all(Focus[Universe](_.persons))
+}
+```
+
+```scala mdoc:compile-only
+import cats.MonadThrow
+import cats.implicits.*
+
+// Service is polymorphic — no IO, no concretion
+class PersonService[F[_]: MonadThrow](repo: PersonRepository[F]) {
+
+  def registerAdult(person: Person): F[Unit] =
+    if (person.age < 18)
+      MonadThrow[F].raiseError(new IllegalArgumentException("must be 18 or older"))
+    else
+      repo.insertMany(List(person)).void
+
+  def listAdults(): F[List[Person]] =
+    repo.listAll().map(_.filter(_.age >= 18))
+}
+```
+
+In tests, instantiate the service by wiring it to an in-memory `PersonRepository[IO]`:
+
+```scala mdoc:compile-only
+import cats.effect.IO
+import mirra.MirraCatsEffect
+import munit.CatsEffectSuite
+import java.util.UUID
+
+class PersonServiceSpec extends CatsEffectSuite {
+
+  // Fresh state for each test — call make inside the test body.
+  def mkRepo: IO[PersonRepository[IO]] =
+    MirraCatsEffect.make[IO, PersonRepository, Universe](MirraPersonRepository, Universe.zero)
+
+  test("registerAdult inserts the person") {
+    for {
+      repo    <- mkRepo
+      service  = new PersonService[IO](repo)
+      person   = Person(UUID.randomUUID(), "Alice", 30)
+      _       <- service.registerAdult(person)
+      result  <- repo.listAll()
+    } yield assertEquals(result, List(person))
+  }
+
+  test("registerAdult rejects minors") {
+    for {
+      repo    <- mkRepo
+      service  = new PersonService[IO](repo)
+      minor    = Person(UUID.randomUUID(), "Bob", 16)
+      result  <- service.registerAdult(minor).attempt
+    } yield assert(result.isLeft)
+  }
+
+  test("listAdults filters correctly") {
+    for {
+      repo    <- mkRepo
+      service  = new PersonService[IO](repo)
+      people   = List(
+                   Person(UUID.randomUUID(), "Alice", 30),
+                   Person(UUID.randomUUID(), "Bob",   16),
+                 )
+      _       <- repo.insertMany(people)
+      result  <- service.listAdults()
+    } yield assertEquals(result.map(_.name), List("Alice"))
+  }
+}
+```
+
+Because `make` returns `F[Alg[F]]`, calling it inside each test body gives every test its own isolated `Ref` — no shared state, no `beforeEach` cleanup.

--- a/docs/src/main/laika/cats-effect.md
+++ b/docs/src/main/laika/cats-effect.md
@@ -68,8 +68,8 @@ class PersonService[F[_]: MonadThrow](repo: PersonRepository[F]) {
     else
       repo.insertMany(List(person)).void
 
-  def listAdults(): F[List[Person]] =
-    repo.listAll().map(_.filter(_.age >= 18))
+  def listAll(): F[List[Person]] =
+    repo.listAll()
 }
 ```
 
@@ -106,17 +106,17 @@ class PersonServiceSpec extends CatsEffectSuite {
     } yield assert(result.isLeft)
   }
 
-  test("listAdults filters correctly") {
+  test("listAll returns all registered persons") {
     for {
       repo    <- mkRepo
       service  = new PersonService[IO](repo)
       people   = List(
                    Person(UUID.randomUUID(), "Alice", 30),
-                   Person(UUID.randomUUID(), "Bob",   16),
+                   Person(UUID.randomUUID(), "Carol", 25),
                  )
       _       <- repo.insertMany(people)
-      result  <- service.listAdults()
-    } yield assertEquals(result.map(_.name), List("Alice"))
+      result  <- service.listAll()
+    } yield assertEquals(result.map(_.name), List("Alice", "Carol"))
   }
 }
 ```

--- a/docs/src/main/laika/directory.conf
+++ b/docs/src/main/laika/directory.conf
@@ -9,4 +9,6 @@ laika.navigationOrder = [
   skunk.md
   munit.md
   zio-test.md
+  cats-effect.md
+  zio.md
 ]

--- a/docs/src/main/laika/zio.md
+++ b/docs/src/main/laika/zio.md
@@ -1,0 +1,129 @@
+# ZIO
+
+The `zio` module provides `MirraZIO.layer` — a factory that lifts an `Alg[[A] =>> Mirra[D, A]]` into a `ULayer[Alg[Task]]` by backing it with a `zio.Ref[D]`.
+
+```scala
+libraryDependencies += "io.github.fristi" %% "mirra-zio" % "<version>"
+```
+
+## How it works
+
+`MirraZIO.layer` wraps `Ref.make(initialState)` in a `ZLayer`, then uses `FunctorK[Alg].mapK` to rewrite every algebra method: each `Mirra[D, A]` (a `State[D, A]` under the hood) is run atomically against the ref via `Ref.modify`.
+
+```
+Alg[[A] =>> Mirra[D, A]]  +  D  →  ULayer[Alg[Task]]
+```
+
+The provided `Alg[Task]` is a live, stateful interpreter. State mutations from one call are visible to subsequent calls, exactly as they would be in a real database — but entirely in-memory.
+
+## Testing services that take `Repo[Task]`
+
+The typical pattern in a ZIO codebase is for services to depend on concrete `Task`-typed repositories injected via `ZLayer`:
+
+```scala mdoc:invisible
+import cats.tagless.{Derive, FunctorK, SemigroupalK}
+import java.util.UUID
+import mirra.Mirra
+import monocle.Focus
+import cats.implicits._
+
+final case class Person(id: UUID, name: String, age: Int)
+
+trait PersonRepository[F[_]] {
+  def create: F[Unit]
+  def insertMany(persons: List[Person]): F[Long]
+  def deleteWhenOlderThen(age: Long): F[Long]
+  def listAll(): F[List[Person]]
+}
+
+object PersonRepository {
+  given FunctorK[PersonRepository]     = Derive.functorK
+  given SemigroupalK[PersonRepository] = Derive.semigroupalK
+}
+
+final case class Universe(persons: List[Person])
+object Universe { def zero: Universe = Universe(Nil) }
+
+object MirraPersonRepository extends PersonRepository[[A] =>> Mirra[Universe, A]] {
+  def create: Mirra[Universe, Unit] = Mirra.unit
+  def insertMany(persons: List[Person]): Mirra[Universe, Long] =
+    Mirra.insertMany(Focus[Universe](_.persons))(persons)
+  def deleteWhenOlderThen(age: Long): Mirra[Universe, Long] =
+    Mirra.delete(Focus[Universe](_.persons))(_.age > age)
+  def listAll(): Mirra[Universe, List[Person]] =
+    Mirra.all(Focus[Universe](_.persons))
+}
+```
+
+```scala mdoc:compile-only
+import zio.*
+
+// Service receives a concrete PersonRepository[Task] — no F[_] abstraction needed in ZIO.
+class PersonService(repo: PersonRepository[Task]) {
+
+  def registerAdult(person: Person): Task[Unit] =
+    ZIO.fail(new IllegalArgumentException("must be 18 or older")).when(person.age < 18) *>
+      repo.insertMany(List(person)).unit
+
+  def listAdults(): Task[List[Person]] =
+    repo.listAll().map(_.filter(_.age >= 18))
+}
+```
+
+Wire the service against an in-memory `PersonRepository[Task]` using `MirraZIO.layer` as a `ZLayer`:
+
+```scala mdoc:compile-only
+import mirra.MirraZIO
+import zio.*
+import zio.test.*
+import java.util.UUID
+
+object PersonServiceSpec extends ZIOSpecDefault {
+
+  // Fresh Ref per test — provide the layer inside each test's ZIO.scoped block,
+  // or use provideLayer at the test level to keep tests isolated.
+  val repoLayer: ULayer[PersonRepository[Task]] =
+    MirraZIO.layer(MirraPersonRepository, Universe.zero)
+
+  def spec = suite("PersonService")(
+
+    test("registerAdult inserts the person") {
+      ZIO.serviceWithZIO[PersonRepository[Task]] { repo =>
+        val service = PersonService(repo)
+        val person  = Person(UUID.randomUUID(), "Alice", 30)
+        for {
+          _      <- service.registerAdult(person)
+          result <- repo.listAll()
+        } yield assertTrue(result == List(person))
+      }
+    }.provide(repoLayer),
+
+    test("registerAdult rejects minors") {
+      ZIO.serviceWithZIO[PersonRepository[Task]] { repo =>
+        val service = PersonService(repo)
+        val minor   = Person(UUID.randomUUID(), "Bob", 16)
+        service.registerAdult(minor).flip.map { err =>
+          assertTrue(err.getMessage == "must be 18 or older")
+        }
+      }
+    }.provide(repoLayer),
+
+    test("listAdults filters correctly") {
+      ZIO.serviceWithZIO[PersonRepository[Task]] { repo =>
+        val service = PersonService(repo)
+        val people  = List(
+                        Person(UUID.randomUUID(), "Alice", 30),
+                        Person(UUID.randomUUID(), "Bob",   16),
+                      )
+        for {
+          _      <- repo.insertMany(people)
+          result <- service.listAdults()
+        } yield assertTrue(result.map(_.name) == List("Alice"))
+      }
+    }.provide(repoLayer),
+
+  )
+}
+```
+
+Each `.provide(repoLayer)` call rebuilds the layer from scratch — including a fresh `Ref` — so tests are fully isolated without any shared state.

--- a/docs/src/main/laika/zio.md
+++ b/docs/src/main/laika/zio.md
@@ -65,8 +65,8 @@ class PersonService(repo: PersonRepository[Task]) {
     ZIO.fail(new IllegalArgumentException("must be 18 or older")).when(person.age < 18) *>
       repo.insertMany(List(person)).unit
 
-  def listAdults(): Task[List[Person]] =
-    repo.listAll().map(_.filter(_.age >= 18))
+  def listAll(): Task[List[Person]] =
+    repo.listAll()
 }
 ```
 
@@ -108,17 +108,17 @@ object PersonServiceSpec extends ZIOSpecDefault {
       }
     }.provide(repoLayer),
 
-    test("listAdults filters correctly") {
+    test("listAll returns all registered persons") {
       ZIO.serviceWithZIO[PersonRepository[Task]] { repo =>
         val service = PersonService(repo)
         val people  = List(
                         Person(UUID.randomUUID(), "Alice", 30),
-                        Person(UUID.randomUUID(), "Bob",   16),
+                        Person(UUID.randomUUID(), "Carol", 25),
                       )
         for {
           _      <- repo.insertMany(people)
-          result <- service.listAdults()
-        } yield assertTrue(result.map(_.name) == List("Alice"))
+          result <- service.listAll()
+        } yield assertTrue(result.map(_.name) == List("Alice", "Carol"))
       }
     }.provide(repoLayer),
 

--- a/docs/src/main/laika/zio.md
+++ b/docs/src/main/laika/zio.md
@@ -53,14 +53,11 @@ object MirraPersonRepository extends PersonRepository[[A] =>> Mirra[Universe, A]
   def listAll(): Mirra[Universe, List[Person]] =
     Mirra.all(Focus[Universe](_.persons))
 }
-```
 
-```scala mdoc:compile-only
 import zio.*
 
 // Service receives a concrete PersonRepository[Task] — no F[_] abstraction needed in ZIO.
 class PersonService(repo: PersonRepository[Task]) {
-
   def registerAdult(person: Person): Task[Unit] =
     ZIO.fail(new IllegalArgumentException("must be 18 or older")).when(person.age < 18) *>
       repo.insertMany(List(person)).unit
@@ -74,7 +71,6 @@ Wire the service against an in-memory `PersonRepository[Task]` using `MirraZIO.l
 
 ```scala mdoc:compile-only
 import mirra.MirraZIO
-import zio.*
 import zio.test.*
 import java.util.UUID
 

--- a/zio/src/main/scala/mirra/MirraZIO.scala
+++ b/zio/src/main/scala/mirra/MirraZIO.scala
@@ -14,7 +14,7 @@ object MirraZIO {
   def layer[Alg[_[_]]: FunctorK, D](
       alg: Alg[[A] =>> Mirra[D, A]],
       initialState: D,
-  ): ULayer[Alg[Task]] =
+  )(using Tag[Alg[Task]]): ULayer[Alg[Task]] =
     ZLayer.fromZIO(
       Ref.make(initialState).map { ref =>
         val nt: ([A] =>> Mirra[D, A]) ~> Task = new (([A] =>> Mirra[D, A]) ~> Task) {

--- a/zio/src/main/scala/mirra/MirraZIO.scala
+++ b/zio/src/main/scala/mirra/MirraZIO.scala
@@ -1,0 +1,30 @@
+package mirra
+
+import cats.tagless.FunctorK
+import cats.~>
+import zio.*
+
+/** Constructs a ZIO `ULayer` for an `Alg` backed by an in-memory `Ref`.
+  *
+  * Each algebra method executes the underlying `State[D, A]` atomically
+  * against a `Ref[D]`, turning `Alg[[A] =>> Mirra[D, A]]` into `Alg[Task]`.
+  */
+object MirraZIO {
+
+  def layer[Alg[_[_]]: FunctorK, D](
+      alg: Alg[[A] =>> Mirra[D, A]],
+      initialState: D,
+  ): ULayer[Alg[Task]] =
+    ZLayer.fromZIO(
+      Ref.make(initialState).map { ref =>
+        val nt: ([A] =>> Mirra[D, A]) ~> Task = new (([A] =>> Mirra[D, A]) ~> Task) {
+          def apply[A](fa: Mirra[D, A]): Task[A] =
+            ref.modify { state =>
+              val (newState, result) = fa.db.run(state).value
+              (result, newState)
+            }
+        }
+        FunctorK[Alg].mapK(alg)(nt)
+      }
+    )
+}

--- a/zio/src/test/scala/mirra/MirraZIOSpec.scala
+++ b/zio/src/test/scala/mirra/MirraZIOSpec.scala
@@ -1,0 +1,98 @@
+package mirra
+
+import cats.tagless.{Derive, FunctorK}
+import monocle.Lens
+import zio.*
+import zio.test.*
+
+// ---- test domain ----
+
+case class Item(id: Int, value: String)
+case class Store(items: List[Item])
+
+object Store {
+  val items: Lens[Store, List[Item]] = Lens[Store, List[Item]](_.items)(v => _.copy(items = v))
+  val empty: Store = Store(Nil)
+}
+
+trait ItemRepo[F[_]] {
+  def insert(item: Item): F[Long]
+  def getAll: F[List[Item]]
+  def delete(id: Int): F[Long]
+}
+
+object ItemRepo {
+  given FunctorK[ItemRepo] = Derive.functorK
+}
+
+object MirraItemRepo extends ItemRepo[[A] =>> Mirra[Store, A]] {
+  def insert(item: Item): Mirra[Store, Long]  = Mirra.insert(Store.items)(item)
+  def getAll: Mirra[Store, List[Item]]        = Mirra.all(Store.items)
+  def delete(id: Int): Mirra[Store, Long]     = Mirra.delete(Store.items)(_.id == id)
+}
+
+// ---- spec ----
+
+object MirraZIOSpec extends ZIOSpecDefault {
+
+  // Each test calls .provide(freshLayer) — ZIO rebuilds the layer per test,
+  // giving every test its own Ref[Store].
+  def freshLayer: ULayer[ItemRepo[Task]] =
+    MirraZIO.layer(MirraItemRepo, Store.empty)
+
+  def spec = suite("MirraZIO")(
+
+    test("insert adds an item and returns 1") {
+      ZIO.serviceWithZIO[ItemRepo[Task]] { repo =>
+        for {
+          count <- repo.insert(Item(1, "foo"))
+          all   <- repo.getAll
+        } yield assertTrue(count == 1L, all == List(Item(1, "foo")))
+      }
+    }.provide(freshLayer),
+
+    test("mutations are visible across subsequent calls") {
+      ZIO.serviceWithZIO[ItemRepo[Task]] { repo =>
+        for {
+          _ <- repo.insert(Item(1, "a"))
+          _ <- repo.insert(Item(2, "b"))
+          all <- repo.getAll
+        } yield assertTrue(all == List(Item(1, "a"), Item(2, "b")))
+      }
+    }.provide(freshLayer),
+
+    test("delete removes matching items and returns count") {
+      ZIO.serviceWithZIO[ItemRepo[Task]] { repo =>
+        for {
+          _     <- repo.insert(Item(1, "a"))
+          _     <- repo.insert(Item(2, "b"))
+          count <- repo.delete(1)
+          all   <- repo.getAll
+        } yield assertTrue(count == 1L, all == List(Item(2, "b")))
+      }
+    }.provide(freshLayer),
+
+    test("delete on absent id returns 0 and leaves state unchanged") {
+      ZIO.serviceWithZIO[ItemRepo[Task]] { repo =>
+        for {
+          _     <- repo.insert(Item(1, "a"))
+          count <- repo.delete(99)
+          all   <- repo.getAll
+        } yield assertTrue(count == 0L, all == List(Item(1, "a")))
+      }
+    }.provide(freshLayer),
+
+    test("each freshLayer call produces independent state") {
+      ZIO.scoped {
+        for {
+          repo1 <- MirraZIO.layer(MirraItemRepo, Store.empty).build.map(_.get[ItemRepo[Task]])
+          repo2 <- MirraZIO.layer(MirraItemRepo, Store.empty).build.map(_.get[ItemRepo[Task]])
+          _     <- repo1.insert(Item(1, "a"))
+          all1  <- repo1.getAll
+          all2  <- repo2.getAll
+        } yield assertTrue(all1 == List(Item(1, "a")), all2 == List.empty)
+      }
+    },
+
+  )
+}


### PR DESCRIPTION
- New `mirra-zio` module: `MirraZIO.layer` lifts `Alg[[A] =>> Mirra[D, A]]` into a `ULayer[Alg[Task]]` backed by a `zio.Ref[D]`
- New `mirra-cats-effect` module: `MirraCatsEffect.make` lifts the same algebra into `F[Alg[F]]` backed by a `cats.effect.Ref[F, D]` (Sync constraint only)
- Docs: cats-effect.md and zio.md show service-level testing examples